### PR TITLE
Fixing the bug that adds a row in the first widget in the page 

### DIFF
--- a/src/DynamicGridForm.php
+++ b/src/DynamicGridForm.php
@@ -140,7 +140,7 @@ class DynamicGridForm extends Widget
      */
     public function getHash()
     {
-        return hash('crc32', time());
+        return hash('crc32', uniqid('', true));
     }
 
     /**


### PR DESCRIPTION
Fixing the bug that adds a row in the first widget in the page  when exists more one widget in the page